### PR TITLE
Add post eval for evaluation in embed mode

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -31,6 +31,11 @@ REDIRECT_URL = (
     if ON_LOCALHOST
     else "https://dev.dilab-ivy.com/ask-ivy"
 )
+EVALUATION_URL = (
+    "http://localhost:8002/evaluation"
+    if ON_LOCALHOST
+    else "https://dev.dilab-ivy.com/evaluation"
+)
 CLIENT_ID = (
     "60p8a9bvteiihrd8g89r5ggabi" if ON_LOCALHOST else "2d7ah9kttong2hdlt4olhtao4d"
 )


### PR DESCRIPTION
- Opens evaluation page in a new window so that it can be used from embedded Ivy
- Send to post-eval page after completing evaluation, from where user can go back to evaluation page
- Remove functionality of going back to ask-ivy page since we don't want students to have that